### PR TITLE
Allow upper case functions

### DIFF
--- a/syntaxes/styled-components.json
+++ b/syntaxes/styled-components.json
@@ -4,7 +4,7 @@
   "patterns": [
     {
       "contentName": "source.css.scss",
-      "begin": "(?:css|scss|sass)\\s*(`)",
+      "begin": "(?:css|Css|scss|Scss|sass|Sass)\\s*(`)",
       "beginCaptures": {
         "1": {
           "patterns": [


### PR DESCRIPTION
Allow sass`` scss`` and css`` to be upper cased (Scss Sass Css)